### PR TITLE
Fix raw URL conversion

### DIFF
--- a/app/workers/crawler.rb
+++ b/app/workers/crawler.rb
@@ -64,7 +64,7 @@ class Crawler
   # to:   https://raw.github.com/banyan/config/master/.vimrc
   def self.convert_2_rawurl(url)
     if url =~ /^https:\/\/github.com\//
-      url.sub!(/^https:\/\/github.com\//, "https://raw.github.com/").sub!(/\/blob\//, "/")
+      url.sub!(/^https:\/\/github.com\//, "https://raw.githubusercontent.com/").sub!(/\/blob\//, "/")
     end
     url
   end


### PR DESCRIPTION
Github uses https://raw.githubusercontent.com/ now, instead of https://raw.github.com/
